### PR TITLE
Added possibility to use related_climate as list (rooms more than 2)

### DIFF
--- a/custom_components/programmable_thermostat/config_schema.py
+++ b/custom_components/programmable_thermostat/config_schema.py
@@ -42,7 +42,7 @@ CLIMATE_SCHEMA = {
     vol.Optional(CONF_MIN_TEMP, default=DEFAULT_MIN_TEMP): vol.Coerce(float),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_TOLERANCE, default=DEFAULT_TOLERANCE): vol.Coerce(float),
-    vol.Optional(CONF_RELATED_CLIMATE): cv.entity_id,
+    vol.Optional(CONF_RELATED_CLIMATE): cv.entity_ids,
     vol.Optional(CONF_HVAC_OPTIONS, default=DEFAULT_HVAC_OPTIONS): vol.In(range(MAX_HVAC_OPTIONS)),
     vol.Optional(CONF_AUTO_MODE, default=DEFAULT_AUTO_MODE): vol.In(AUTO_MODE_OPTIONS),
     vol.Optional(CONF_INITIAL_HVAC_MODE): vol.In(INITIAL_HVAC_MODE_OPTIONS),


### PR DESCRIPTION
Hi there!

I was trying to configure my climate control with 3 rooms with one shared heater, but was found, that related_climate property supports only single entity. I've checked this code at my Home Assistance and seems like it works correctly (at least for heat mode).

Now it is possible to use related_climate as list of climate entities like this:
```yaml

  - platform: programmable_thermostat
    name: pterm_room_11
    heater:
      - switch.complex_boiler
    related_climate:
      - climate.pterm_room_21
      - climate.pterm_room_22
    actual_temp_sensor: sensor.room11_temperature
    target_temp_sensor: input_number.dest_temp_11

  - platform: programmable_thermostat
    name: pterm_room_21
    heater:
      - switch.complex_boiler
    related_climate:
      - climate.pterm_room_11
      - climate.pterm_room_22
    actual_temp_sensor: sensor.room21_temperature
    target_temp_sensor: input_number.dest_temp_21

  - platform: programmable_thermostat
    name: pterm_room_22
    heater:
      - switch.complex_boiler
    related_climate:
      - climate.pterm_room_11
      - climate.pterm_room_21
    actual_temp_sensor: sensor.room22_temperature
    target_temp_sensor: input_number.dest_temp_22
```

 Could you please review is my solution correct and merge this?

Thanks

