### PR TITLE
Add sensor, heaters and coolers into state attributes

### DIFF
--- a/custom_components/programmable_thermostat/climate.py
+++ b/custom_components/programmable_thermostat/climate.py
@@ -38,7 +38,10 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from .const import (
     VERSION,
     DOMAIN,
-    PLATFORM
+    PLATFORM,
+    ATTR_HEATER_IDS,
+    ATTR_COOLER_IDS,
+    ATTR_SENSOR_ID
 )
 from .config_schema import(
     CLIMATE_SCHEMA,
@@ -614,3 +617,14 @@ class ProgrammableThermostat(ClimateEntity, RestoreEntity):
         Need to be one of CURRENT_HVAC_*.
         """
         return self._hvac_action
+
+    @property
+    def extra_state_attributes(self):
+        """Return entity specific state attributes to be saved. """
+        attributes = {}
+
+        attributes[ATTR_HEATER_IDS] = self.heaters_entity_ids
+        attributes[ATTR_COOLER_IDS] = self.coolers_entity_ids
+        attributes[ATTR_SENSOR_ID] = self.sensor_entity_id
+
+        return attributes

--- a/custom_components/programmable_thermostat/const.py
+++ b/custom_components/programmable_thermostat/const.py
@@ -28,3 +28,8 @@ AUTO_MODE_OPTIONS = ['all', 'heating', 'cooling']
 INITIAL_HVAC_MODE_OPTIONS = ['', HVAC_MODE_COOL, HVAC_MODE_HEAT, HVAC_MODE_OFF, HVAC_MODE_HEAT_COOL]
 INITIAL_HVAC_MODE_OPTIONS_OPTFLOW = ['null', HVAC_MODE_COOL, HVAC_MODE_HEAT, HVAC_MODE_OFF, HVAC_MODE_HEAT_COOL]
 REGEX_STRING = r'((?P<hours>\d+?):(?=(\d+?:\d+?)))?((?P<minutes>\d+?):)?((?P<seconds>\d+?))?$'
+
+#Attributes
+ATTR_HEATER_IDS = "heater_ids"
+ATTR_COOLER_IDS = "cooler_ids"
+ATTR_SENSOR_ID = "sensor_id"


### PR DESCRIPTION
There was a need to monitor the availability of sensors, heaters and coolers for working thermostats. In order not to conduct a correspondence separately, the easiest way is to display them in the attributes of the thermostat state.