### PR TITLE
Fixed reload issue

### DIFF
--- a/custom_components/programmable_thermostat/climate.py
+++ b/custom_components/programmable_thermostat/climate.py
@@ -73,7 +73,7 @@ async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Add ProgrammableThermostat entities from configuration.yaml."""
     _LOGGER.info("Setup entity coming from configuration.yaml named: %s", config.get(CONF_NAME))
-    await async_setup_reload_service(hass, DOMAIN, PLATFORM)
+    await async_setup_reload_service(hass, DOMAIN, [PLATFORM])
     async_add_entities([ProgrammableThermostat(hass, config)])
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
@@ -84,7 +84,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
     else:
         result = config_entry.data
     _LOGGER.info("setup entity-config_entry_data=%s",result)
-    await async_setup_reload_service(hass, DOMAIN, PLATFORM)
+    await async_setup_reload_service(hass, DOMAIN, [PLATFORM])
     async_add_devices([ProgrammableThermostat(hass, result)])
 
 

--- a/custom_components/programmable_thermostat/const.py
+++ b/custom_components/programmable_thermostat/const.py
@@ -8,7 +8,7 @@ from homeassistant.components.climate.const import (
 #Generic
 VERSION = '8.2'
 DOMAIN = 'programmable_thermostat'
-PLATFORM = 'climate'
+PLATFORM = ['climate']
 ISSUE_URL = 'https://github.com/custom-components/climate.programmable_thermostat/issues'
 CONFIGFLOW_VERSION = 4
 

--- a/custom_components/programmable_thermostat/const.py
+++ b/custom_components/programmable_thermostat/const.py
@@ -8,7 +8,7 @@ from homeassistant.components.climate.const import (
 #Generic
 VERSION = '8.2'
 DOMAIN = 'programmable_thermostat'
-PLATFORM = ['climate']
+PLATFORM = 'climate'
 ISSUE_URL = 'https://github.com/custom-components/climate.programmable_thermostat/issues'
 CONFIGFLOW_VERSION = 4
 


### PR DESCRIPTION
Fixes #44.

The `async_setup_reload_service()` function takes a list as the third argument, not a string. See the method definition here: https://github.com/home-assistant/core/blob/2023.8.4/homeassistant/helpers/reload.py#L167