### PR TITLE
Fix options flow initialization crash in config entry editing

### DIFF
--- a/custom_components/programmable_thermostat/config_flow.py
+++ b/custom_components/programmable_thermostat/config_flow.py
@@ -164,9 +164,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry):
         """Initialize."""
+        super().__init__(config_entry)
         self._errors = {}
         self._data = {}
-        self.config_entry = config_entry
         if self.config_entry.options == {}:
             self._data.update(self.config_entry.data)
         else:
@@ -274,7 +274,7 @@ class EmptyOptions(config_entries.OptionsFlow):
 
     def __init__(self, config_entry):
         """Just set the config_entry parameter."""
-        self.config_entry = config_entry
+        super().__init__(config_entry)
 
 #####################################################
 ############## DATA VALIDATION FUCTION ##############


### PR DESCRIPTION
### Motivation
- Risolvere il crash che si verifica aprendo o modificando le opzioni dell'integrazione a causa dell'assegnazione diretta di una property di sola lettura `config_entry` su `OptionsFlow`.

### Description
- In `custom_components/programmable_thermostat/config_flow.py` il costruttore di `OptionsFlowHandler` ora chiama `super().__init__(config_entry)` e la stessa modifica è stata applicata a `EmptyOptions` invece di assegnare `self.config_entry`, lasciando che la base `OptionsFlow` gestisca la proprietà.

### Testing
- Eseguito `python -m compileall custom_components/programmable_thermostat/config_flow.py` e la compilazione è riuscita senza errori.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b413a05cac832ca3b1d157b0bb9d6c)