### PR TITLE
Use private `_config_entry` attribute in options flows

### DIFF
--- a/custom_components/programmable_thermostat/config_flow.py
+++ b/custom_components/programmable_thermostat/config_flow.py
@@ -164,13 +164,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry):
         """Initialize."""
+        self._config_entry = config_entry
         self._errors = {}
         self._data = {}
-        self.config_entry = config_entry
-        if self.config_entry.options == {}:
-            self._data.update(self.config_entry.data)
+        if self._config_entry.options == {}:
+            self._data.update(self._config_entry.data)
         else:
-            self._data.update(self.config_entry.options)
+            self._data.update(self._config_entry.options)
         _LOGGER.debug("_data to start options flow: %s", self._data)
 
     """ INITIATE CONFIG FLOW """
@@ -274,7 +274,7 @@ class EmptyOptions(config_entries.OptionsFlow):
 
     def __init__(self, config_entry):
         """Just set the config_entry parameter."""
-        self.config_entry = config_entry
+        self._config_entry = config_entry
 
 #####################################################
 ############## DATA VALIDATION FUCTION ##############


### PR DESCRIPTION
### Motivation
- Standardize the options flow implementation to consistently store the passed `config_entry` on a private attribute to avoid inconsistent attribute access and potential attribute errors in the options flow code.

### Description
- In `custom_components/programmable_thermostat/config_flow.py` set `self._config_entry = config_entry` in `OptionsFlowHandler.__init__` and replace references to `self.config_entry` with `self._config_entry`, and also rename `self.config_entry` to `self._config_entry` in `EmptyOptions.__init__`.

### Testing
- Ran linting (`flake8`) and the existing unit test suite for the integration; lint and tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b413a05cac832ca3b1d157b0bb9d6c)