### PR TITLE
Use correct platform unload API and normalize config_entry usage in options flow

### DIFF
--- a/custom_components/programmable_thermostat/__init__.py
+++ b/custom_components/programmable_thermostat/__init__.py
@@ -45,7 +45,7 @@ async def async_setup_entry(hass, config_entry: ConfigEntry):
 async def async_unload_entry(hass, config_entry):
     """Unload a config entry."""
     _LOGGER.debug("async_unload_entry: %s", config_entry)
-    return await hass.config_entries.async_forward_entry_unload(config_entry, PLATFORM)
+    return await hass.config_entries.async_unload_platforms(config_entry, PLATFORM)
 
 async def update_listener(hass, config_entry):
     """Handle options update."""

--- a/custom_components/programmable_thermostat/config_flow.py
+++ b/custom_components/programmable_thermostat/config_flow.py
@@ -164,13 +164,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry):
         """Initialize."""
+        self._config_entry = config_entry
         self._errors = {}
         self._data = {}
-        self.config_entry = config_entry
-        if self.config_entry.options == {}:
-            self._data.update(self.config_entry.data)
+        if self._config_entry.options == {}:
+            self._data.update(self._config_entry.data)
         else:
-            self._data.update(self.config_entry.options)
+            self._data.update(self._config_entry.options)
         _LOGGER.debug("_data to start options flow: %s", self._data)
 
     """ INITIATE CONFIG FLOW """
@@ -274,7 +274,7 @@ class EmptyOptions(config_entries.OptionsFlow):
 
     def __init__(self, config_entry):
         """Just set the config_entry parameter."""
-        self.config_entry = config_entry
+        self._config_entry = config_entry
 
 #####################################################
 ############## DATA VALIDATION FUCTION ##############


### PR DESCRIPTION
### Motivation

- Update the integration to call the correct Home Assistant platform unload API to match current core APIs and avoid unload failures.
- Normalize the `config_entry` attribute usage inside the options flow to prevent attribute collisions and make option handling consistent.

### Description

- Replace `hass.config_entries.async_forward_entry_unload(config_entry, PLATFORM)` with `hass.config_entries.async_unload_platforms(config_entry, PLATFORM)` in `async_unload_entry` to use the proper unload call.
- Refactor `OptionsFlowHandler` to store the entry on `self._config_entry` and update all references to use `self._config_entry` when initializing option data and merging defaults.
- Update `EmptyOptions` to set `self._config_entry` instead of `self.config_entry` for consistency with the options flow refactor.

### Testing

- Ran static linting with `flake8` which completed without new lint errors.
- Ran unit tests with `pytest` and the test suite passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b413a05cac832ca3b1d157b0bb9d6c)